### PR TITLE
Added end page and removed prev button from first card

### DIFF
--- a/src/__tests__/review.test.js
+++ b/src/__tests__/review.test.js
@@ -17,12 +17,12 @@ test('Next and previous, and wrap around',() => {
   newReview.handlePrevClick();
   expect(newReview.cardSide).toBe(false);
   expect(newReview.cardNumber).toBe(newReview.deck.cardHolder.length-1);
-  newReview.handleNextClick();
-  expect(newReview.cardSide).toBe(true);
-  expect(newReview.cardNumber).toBe(0);
-  newReview.deck.cardHolder.map(() => newReview.handleNextClick());
-  newReview.deck.cardHolder.map(() => newReview.handleNextClick());
-  expect(newReview.cardSide).toBe(true);
-  expect(newReview.cardNumber).toBe(0);
+  // newReview.handleNextClick();
+  // expect(newReview.cardSide).toBe(true);
+  // expect(newReview.cardNumber).toBe(0);
+  // newReview.deck.cardHolder.map(() => newReview.handleNextClick());
+  // newReview.deck.cardHolder.map(() => newReview.handleNextClick());
+  // expect(newReview.cardSide).toBe(true);
+  // expect(newReview.cardNumber).toBe(0);
 
 });

--- a/src/components/Level1Card.js
+++ b/src/components/Level1Card.js
@@ -11,29 +11,42 @@ class Level1Card extends React.Component {
   }
 
   render() {
-    return (
-      <div className="playCard">
-        <div className="cardImg"> Image</div>
-        <div
-          className="cardText">{(this.state.review.cardSide) ? this.state.review.deck.cardHolder[this.state.currentCard].textLanguageTwo
-          : this.state.review.deck.cardHolder[this.state.currentCard].textLanguageOne}</div>
-        <div className="card-btns">
-          <div className="audioBtn" onClick={() => this.state.review.playAudio()}>audio
-          </div>
-          <div onClick={() => {
-            this.state.review.handlePrevClick();
-            this.setState({currentCard: this.state.review.cardNumber})
-          }} className="navBtn">prev
-          </div>
-          <div onClick={() => {
-            this.state.review.handleNextClick();
-            this.setState({currentCard: this.state.review.cardNumber})
-          }} className="navBtn">next
-          </div>
+    if (this.state.currentCard === this.state.review.deck.cardHolder.length){
+      return(
+        <div>
+          <h1>You Finished</h1>
+          <button onClick={() => this.props.clearLevel()}>Go Back</button>
         </div>
+      );
+    } else {
+      return (
+        <div className="playCard">
+          <div className="cardImg"> Image</div>
+          <div
+            className="cardText">{(this.state.review.cardSide) ? this.state.review.deck.cardHolder[this.state.currentCard].textLanguageTwo
+            : this.state.review.deck.cardHolder[this.state.currentCard].textLanguageOne}</div>
+          <div className="card-btns">
+            <div className="audioBtn" onClick={() => this.state.review.playAudio()}>audio
+            </div>
+            {
+              (this.state.currentCard === 0 && this.state.review.cardSide === true)?
+                null:
+                <div onClick={() => {
+                    this.state.review.handlePrevClick();
+                    this.setState({currentCard: this.state.review.cardNumber})
+                  }} className="navBtn">prev
+                </div>
+            }
+            <div onClick={() => {
+              this.state.review.handleNextClick();
+              this.setState({currentCard: this.state.review.cardNumber})
+            }} className="navBtn">next
+            </div>
+          </div>
 
-      </div>
-    );
+        </div>
+      );
+    }
   }
 };
 

--- a/src/components/LevelSelector.js
+++ b/src/components/LevelSelector.js
@@ -17,10 +17,16 @@ class LevelSelector extends React.Component {
     })
   }
 
+  clearLevel = () => {
+    this.setState({
+      levelClicked:'',
+    })
+  }
+
   render(){
     if(this.state.levelClicked === 'review'){
       return(
-        <Level1Card />
+        <Level1Card clearLevel={this.clearLevel}/>
       );
     } else if (this.state.levelClicked === 'recognize'){
 

--- a/src/components/review.js
+++ b/src/components/review.js
@@ -9,11 +9,12 @@ class review {
 
   handleNextClick = () => {
     if (!this.cardSide) {
-      if (this.cardNumber === this.deck.cardHolder.length - 1) {
-        this.cardNumber = 0;
-      } else {
+      // if (this.cardNumber === this.deck.cardHolder.length - 1) {
+      //   // this.cardNumber = 0;
+        
+      // } else {
         this.cardNumber++;
-      }
+      // }
     }
     this.cardSide = !this.cardSide;
 


### PR DESCRIPTION
Had to comment out tests to wrap around card deck as that functionality no long exists.
Modified review.js to take out wrapping functionality.
Modified level1card to change to end page after last card and conditionally remove prev button.
Added function to levelselector to pass to the card displays to be able to reset it back to the level selector.